### PR TITLE
remove all "__" properties due to a graphql error

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,12 @@ type Book {
   publishers: [Publisher]
 }
 ```
+
+## Graphql private properties
+
+Graphql does not allow properties beginning with "__" in types. Otherwise, it will print a message error like this :
+```
+Name "__t" must not begin with "__", which is reserved by GraphQL introspection. In a future release of graphql this will become a hard error.
+````
+
+By default, this kind of properties is removed by mongoose-graphql.

--- a/lib/getTypeTree.js
+++ b/lib/getTypeTree.js
@@ -46,7 +46,7 @@ const getTypeTree = (schemaPaths) => {
   const typeTree = {};
 
   forOwn(schemaPaths, (path, key) => {
-    if (key === '__v') {
+    if (/__/.test(key)) {
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-graphql",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Convert a mongoose model to a GraphQL type string",
   "repository": "zipdrug/mongoose-graphql",
   "main": "dist/mongoose-graphql.js",

--- a/test/getTypeTree-test.js
+++ b/test/getTypeTree-test.js
@@ -122,3 +122,28 @@ test('getTypeTree supports complex arrays', (t) => {
 
   t.deepEqual(getTypeTree(complexArray), complexArrayTree);
 });
+
+test('getTypeTree removes graphql private properties ("__" properties used for graphql introspection)', (t) => {
+  const primitivePaths = {
+    isRush: {
+      instance: 'Boolean',
+    },
+    name: {
+      instance: 'String',
+    },
+    no: {
+      instance: 'Number',
+    },
+    __t: {
+      instance: 'String',
+    },
+  };
+
+  const primitiveTree = {
+    isRush: 'Boolean',
+    name: 'String',
+    no: 'Float',
+  };
+
+  t.deepEqual(getTypeTree(primitivePaths), primitiveTree);
+});


### PR DESCRIPTION
Due to an error with Graphql while using this package, I modified slightly this package.
The error was:
```
Name "__t" must not begin with "__", which is reserved by GraphQL introspection. In a future release of graphql this will become a hard error.
````

Because of the use of a discriminator with Mongo, Mongoose added a "__t" property in the model. So it was passed by the mongoose-graphql package to the type. While I still need the "__t" property in the model, Graphql considers this as a problem in the type.

So, I removed all "__" properties in type to comply with Graphql policy. I updated the README doc and tests.